### PR TITLE
perf(upgrade_release_management): upgraded from releases to tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Use this role to install the wkhtmltopdf console pdf generator + the full set of googlefonts to be used inside the generated pdf documents.
 
+This version relies on the wkthmltopdf [tags](https://github.com/wkhtmltopdf/packaging/tags) and tries to fetch the latest tag or use a specific one set in the role variables.
+
+Sadly the release process of wkhtmltopdf is not very stable. At the time being, older releases of ubuntu (focal, bionic) are only supported for the ppv64 architecture on the latest tags, while even the releases are not stable maintained. If you need to select the specific release/tag for an older version of ubuntu, fetch the latest v2.x release of this module and set the wkhtmltopdf release selection as described in the readme of that version.
+
 ### Requirements
 
 This role requires ubuntu
@@ -14,13 +18,10 @@ This role requires ubuntu
 
 The default set of variables can be used to define the wkhtmltopdf version to be installed
 
-    wkhtmltopdf_release:
-      jammy: "0.12.6.1-2"
-      focal: "0.12.6-1"
-      bionic: "0.12.6-1"
+    wkhtmltopdf_tag: latest  # or set accordingly, e.g. 0.12.6.1-3
     wkhtmltopdf_install_google_fonts: true
 
-Extract the actual full release version from [here](https://wkhtmltopdf.org/downloads.html).
+Extract the actual tag version from [here](https://github.com/wkhtmltopdf/packaging/tags).
 
 ### Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-wkhtmltopdf_release:
-  jammy: "0.12.6.1-2"
-  focal: "0.12.6-1"
-  bionic: "0.12.6-1"
+wkhtmltopdf_tag: latest
 wkhtmltopdf_install_google_fonts: true
 ...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,8 +13,6 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - jammy
-    - focal
-    - bionic
 
   galaxy_tags:
   - wkhtml

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,8 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    # wkhtmltopdf_patch_release: "x.x.x"
-    # wkhtmltopdf_full_release: "x.x.x.x-x"
+    # wkhtmltopdf_tag: "x.x.x.x-x"
     wkhtmltopdf_install_google_fonts: false
   tasks:
   - name: "Include andrelohmann.wkhtmltopdf"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,34 +18,6 @@ platforms:
   cgroupns_mode: host
   pre_build_image: false
   dockerfile: Dockerfile.j2
-- name: ubuntu_focal
-  image: ubuntu:20.04
-  command: ""
-  tmpfs:
-  - /tmp
-  - /run
-  - /run/lock
-  priviledged: true
-  volumes:
-  - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - /var/lib/containerd
-  cgroupns_mode: host
-  pre_build_image: false
-  dockerfile: Dockerfile.j2
-- name: ubuntu_bionic
-  image: ubuntu:18.04
-  command: ""
-  tmpfs:
-  - /tmp
-  - /run
-  - /run/lock
-  priviledged: true
-  volumes:
-  - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - /var/lib/containerd
-  cgroupns_mode: host
-  pre_build_image: false
-  dockerfile: Dockerfile.j2
 provisioner:
   name: ansible
 verifier:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,28 +11,35 @@
     cache_valid_time: 3600
   vars:
     packages:
-    # - build-essential
-    # - git
-    - curl
-    # - xvfb
-    # - libxrender1
-    # - fontconfig
-    # - xfonts-75dpi
+    - git
 
-- name: Setting host facts using complex arguments
-  ansible.builtin.set_fact:
-    wkhtmltopdf_full_release: "{{ wkhtmltopdf_release[ansible_distribution_release] }}"
+- name: Extract latest tag number
+  when: wkhtmltopdf_tag == "latest"
+  block:
+
+  - name: Fetch latest wkhtmltopdf tag
+    ansible.builtin.shell: >
+      set -o pipefail && \
+      git ls-remote --tags https://github.com/wkhtmltopdf/packaging.git | cut -d/ -f3- | tail -n1
+    args:
+      executable: /bin/bash
+    register: latest_wkhtmltopdf_tag
+    changed_when: false
+
+  - name: Set wkhtmltopdf_tag
+    ansible.builtin.set_fact:
+      wkhtmltopdf_tag: "{{ latest_wkhtmltopdf_tag.stdout }}"
 
 - name: Download wkhtmltopdf package for Linux arm64
   ansible.builtin.get_url:
-    url: "https://github.com/wkhtmltopdf/packaging/releases/download/{{ wkhtmltopdf_full_release }}/wkhtmltox_{{ wkhtmltopdf_full_release }}.{{ ansible_distribution_release }}_arm64.deb"
+    url: "https://github.com/wkhtmltopdf/packaging/releases/download/{{ wkhtmltopdf_tag }}/wkhtmltox_{{ wkhtmltopdf_tag }}.{{ ansible_distribution_release }}_arm64.deb"
     dest: /tmp/wkhtmltopdf.deb
     mode: '0644'
   when: "'aarch64' in ansible_architecture and 'Linux' == ansible_system"
 
 - name: Download wkhtmltopdf package for Linux amd64
   ansible.builtin.get_url:
-    url: "https://github.com/wkhtmltopdf/packaging/releases/download/{{ wkhtmltopdf_full_release }}/wkhtmltox_{{ wkhtmltopdf_full_release }}.{{ ansible_distribution_release }}_amd64.deb"
+    url: "https://github.com/wkhtmltopdf/packaging/releases/download/{{ wkhtmltopdf_tag }}/wkhtmltox_{{ wkhtmltopdf_tag }}.{{ ansible_distribution_release }}_amd64.deb"
     dest: /tmp/wkhtmltopdf.deb
     mode: '0644'
   when: "'x86_64' in ansible_architecture and 'Linux' == ansible_system"
@@ -58,10 +65,6 @@
       packages:
       - unzip
       - findutils
-      # - xvfb
-      # - libxrender1
-      # - fontconfig
-      # - xfonts-75dpi
 
   - name: Fetching google fonts
     ansible.builtin.get_url:


### PR DESCRIPTION
BREAKING CHANGE: as the release management of wkhtmltopdf is not stable, the role switched to the usage of tags; it no longer supports ubuntuntu versions other than jammy